### PR TITLE
co-maintainers: remove dependency on expac

### DIFF
--- a/package/co-maintainers
+++ b/package/co-maintainers
@@ -48,7 +48,9 @@ done
 find_packages(){
     test ${#filter} -eq 0 && filter=(core extra community multilib)
     if ((local_packages)); then
-        expac -S "%r %a %n" $(expac %n) | grep -P "^($(echo "${filter[*]}" | tr ' ' '|'))"
+        LANG=C pacman -Si $(pacman -Qq) | \
+            awk '/^Repository/ { repo=$3 } /^Name/ { name=$3 } /^Architecture/ { arch=$3 } /^$/ { print repo " " arch " " name }' | \
+            grep -P "^($(echo "${filter[*]}" | tr ' ' '|'))"
     else
         curl -s "https://www.archlinux.org/packages/search/json/?${maintainer_query}" | jq -r '.results[] | "\(.repo) \(.arch) \(.pkgname)"' | sort | uniq
     fi
@@ -61,10 +63,10 @@ while read -r pkg; do
 done <<< "$(find_packages)"
 
 while read -r repo arch pkg; do
-	format='select(.maintainers | length == $LIMIT) | "\(.pkgbase)"'
-	if ((see_maintainers)); then
-		format='select(.maintainers | length == $LIMIT) | "\(.pkgbase)", (.maintainers | join(" "))'
-	fi
+    format='select(.maintainers | length == $LIMIT) | "\(.pkgbase)"'
+    if ((see_maintainers)); then
+        format+=', (.maintainers | join(" "))'
+    fi
     curl -s "https://www.archlinux.org/packages/$repo/$arch/$pkg/json/" | \
         jq -r --argjson LIMIT $limit_maintainers "$format"
 done <<< "$(IFS=$'\n'; echo "${packages[*]}")"


### PR DESCRIPTION
Currently, archlinux-contrib does not depend nor optdepend on expac
This commit removes expac usage from `co-maintainers`.
Alternatively, expac will have to be added to the opt(depends) of the current package (cc @Foxboron),
though I don't see a particular advantage over just using awk here.

Also fixes formatting (mixed tabs/spaces)