### PR TITLE
checkservices: fix parsing of systemctl command for version 246.1

### DIFF
--- a/admin/checkservices
+++ b/admin/checkservices
@@ -92,7 +92,7 @@ confirm() {
 
 # get running systemd services
 get_services() {
-    systemctl --no-legend --full --type service --state running|cut -f1 -d' '
+    systemctl --no-legend --full --type service --state running|awk '{print $1}'
 }
 
 # get systemd services with updated mapped files


### PR DESCRIPTION
The command in [get_services](https://github.com/archlinux/contrib/blob/master/admin/checkservices#L93-L96):

    systemctl --no-legend --full --type service --state running|cut -f1 -d' '

The `cut` worked up to systemd 245.7 which printed something like this:
```
$ systemctl --no-legend --full --type service --state running
systemd-journald.service  loaded active running Journal Service
systemd-logind.service    loaded active running Login Service
systemd-networkd.service  loaded active running Network Service
systemd-resolved.service  loaded active running Network Name Resolution
systemd-timesyncd.service loaded active running Network Time Synchronization
systemd-udevd.service     loaded active running udev Kernel Device Manager
```
But systemd 246.1 adds leading spaces (or, more exactly, `--no-legend` does not remove the leading spaces), so the `cut` command does not work as expected:
```
$ systemctl --no-legend --full --type service --state running
  systemd-journald.service     loaded active running Journal Service
  systemd-logind.service       loaded active running User Login Management
  systemd-networkd.service     loaded active running Network Service
  systemd-resolved.service     loaded active running Network Name Resolution
  systemd-timesyncd.service    loaded active running Network Time Synchronization
  systemd-udevd.service        loaded active running Rule-based Manager for Device Events and Files
```
An easy solution is to use `awk {print $1}` instead of `cut`.