### PR TITLE
staging2testing: Merge commands to avoid breakage

### DIFF
--- a/package/staging2testing
+++ b/package/staging2testing
@@ -7,7 +7,7 @@ import sys
 
 import requests
 
-CMD = './db-move {} {} '
+CMD = './db-move {} {} {}'
 
 
 def main(url):
@@ -32,11 +32,11 @@ def main(url):
             pkgs.add(pkgbase)
 
     if pkgs:
-        print(CMD.format('staging', 'testing') + ' '.join(pkgs))
+        print(CMD.format('staging', 'testing', ' '.join(pkgs)))
     if communitypkgs:
-        print(CMD.format('community-staging', 'community-testing') + ' '.join(communitypkgs))
+        print(CMD.format('community-staging', 'community-testing', ' '.join(communitypkgs)))
     if multilibpkgs:
-        print(CMD.format('multilib-staging', 'multilib-testing') + ' '.join(multilibpkgs))
+        print(CMD.format('multilib-staging', 'multilib-testing', ' '.join(multilibpkgs)))
 
 
 if __name__ == "__main__":

--- a/package/staging2testing
+++ b/package/staging2testing
@@ -7,11 +7,13 @@ import sys
 
 import requests
 
-CMD = './db-move {} {} {}'
+CMD = './db-move {} {} '
 
 
 def main(url):
     pkgs = set()
+    communitypkgs = set()
+    multilibpkgs = set()
 
     try:
         r = requests.get(url)
@@ -21,19 +23,20 @@ def main(url):
 
     for pkg in r.json()['packages']:
         pkgbase = pkg['pkgbase']
-        sourcerepo = 'staging'
-        repo = 'testing'
 
         if pkg['repo'] == 'community':
-            sourcerepo = 'community-staging'
-            repo = 'community-testing'
+            communitypkgs.add(pkgbase)
         elif pkg['repo'] == 'multilib':
-            sourcerepo = 'community-staging'
-            repo = 'multilib-testing'
+            multilibpkgs.add(pkgbase)
+        else:
+            pkgs.add(pkgbase)
 
-        pkgs.add(CMD.format(sourcerepo, repo, pkgbase))
-
-    print('\n'.join(sorted(pkgs)))
+    if pkgs:
+        print(CMD.format('staging', 'testing') + ' '.join(pkgs))
+    if communitypkgs:
+        print(CMD.format('community-staging', 'community-testing') + ' '.join(communitypkgs))
+    if multilibpkgs:
+        print(CMD.format('multilib-staging', 'multilib-testing') + ' '.join(multilibpkgs))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Running db-move multiple times could lead to breakage due to repository
being inconsistent for the time being. This change merges all pkgbases
of the same repo to a single command so each db itself is always
consistent.