### PR TITLE
Add support for requests that return a 301 response code.

### DIFF
--- a/package/pkgsearch
+++ b/package/pkgsearch
@@ -6,7 +6,7 @@ set -o errexit
 shopt -s extglob
 
 help(){
-    cat << EOF 
+    cat << EOF
 Usage:
   $PROGRAM
 
@@ -31,7 +31,7 @@ Example:
     Packages installed on the system from [core] with 1 maintainer
     $ pkgsearch -q -f core -l 1
 
-    Locally installed packages from [community], orphaned, and flagged out-of-date 
+    Locally installed packages from [community], orphaned, and flagged out-of-date
     $ pkgsearch -q -f community -l 0 -m orphan -o
 
 EOF
@@ -69,7 +69,7 @@ find_packages(){
         filter=("${filter[@]^}") # Uppercase the repo names
         filter=("${filter[@]/#/&repo=}") # Prepend &repo= to all elements
         query="?${maintainer_query}${packager_query}$(printf "%s" "${filter[@]}")&flagged=$out_of_date"
-        curl -s "https://www.archlinux.org/packages/search/json/$query" \
+        curl -L -s "https://www.archlinux.org/packages/search/json/$query" \
           | jq -r '.results[] | "\(.repo) \(.arch) \(.pkgname) \(.pkgbase)"' | sort | uniq
     fi
 }
@@ -81,6 +81,6 @@ while read -r repo arch pkg _; do
       # shellcheck disable=SC2016
       format="select(.maintainers | length == \$LIMIT) | \"\(${name})\", (.maintainers | join(\" \"))"
     fi
-    curl -s "https://www.archlinux.org/packages/$repo/$arch/$pkg/json/" | \
+    curl -L -s "https://www.archlinux.org/packages/$repo/$arch/$pkg/json/" | \
         jq -r --argjson LIMIT "$limit_maintainers" "$format"
 done <<< "$(find_packages | sort -u -k4,4)"


### PR DESCRIPTION
1. Why is this change neccesary?
The pkgsearch script can't handle a request that returns a 301 because curl is
not redoing requests.

2. How does it address the issue?
By adding a flag so curl redos request on the new place.

3. What side effects does this change have?
Closes #38

---

Reviewed by Santiago Torres-Arias <santiago@archlinux.org>