### PR TITLE
[compose-asa] update mailing list address

### DIFF
--- a/security/compose-asa
+++ b/security/compose-asa
@@ -13,7 +13,7 @@ for asa in $(curl -s "https://security.archlinux.org/todo/json" | jq -r '.adviso
 	read -r -e -p "Send $asa? [y/N]" PR
 	[[ $PR == "n" || $PR == "N" || $PR == "" ]]	 && continue
 	TMPFILE=$(mktemp)
-	echo "To: arch-security@archlinux.org" > "$TMPFILE"
+	echo "To: arch-security@lists.archlinux.org" > "$TMPFILE"
 	curl -s "https://security.archlinux.org/$asa/generate/raw" >> "$TMPFILE"
 	$COMPOSE_ASA_EMAIL "$TMPFILE"
 done


### PR DESCRIPTION
The old alias is deprecated and will be removed soon, cf. https://lists.archlinux.org/pipermail/arch-dev-public/2021-June/030462.html