### PR TITLE
Update parse-submodules output messages

### DIFF
--- a/package/parse-submodules
+++ b/package/parse-submodules
@@ -390,8 +390,8 @@ fi
 cd "${tempdir}"
 touch "${outfile}"
 __SHORT_HASH="$(get-short-hash "${__GIT_REMOTE}" "${__GIT_REF}")"
-echo '# Your sources array should look something like:
-sources=(
+echo '# Your source array should look something like this:
+source=(
   "${pkgname}::'${__GIT_REMOTE}'#commit='${__SHORT_HASH}'"' >>"${outfile}"
 __REMOTE_PREFIX="$(get-proto "${__GIT_REMOTE}")$(get-user "${__GIT_REMOTE}")$(get-host "${__GIT_REMOTE}")$(get-port "${__GIT_REMOTE}")"
 for name in $(get-module-names "${gmdfile}"); do
@@ -406,7 +406,7 @@ for pid in $pids; do
 done
 echo ')' >>"${outfile}"
 
-echo '# Put the following in your PKGBUILD prepare function:
+echo '# Update the prepare function in your PKGBUILD to initialize the submodules:
 prepare() {
   cd "${srcdir}/${pkgname}"
   git submodule init


### PR DESCRIPTION
In order the clarify the usage of the `parse-submodules` output:

- "sources array" phrase is replaced with "source array" and same is applied for `source=()`, which was previously `sources=()"`
- The echo message that points out the required update of `prepare()` function is also made more clear.

