### PR TITLE
Handle default main branch in git

### DIFF
--- a/aur/repos2aur
+++ b/aur/repos2aur
@@ -24,15 +24,19 @@ function cleanup {
 trap cleanup EXIT
 
 REPONAME=$(basename "$PKGBASE")
-git clone "ssh://aur@aur.archlinux.org/$REPONAME.git" $TMPDIR
+
+# The AUR does not support a main default branch, so we have to git init with a
+# master branch explictly https://bugs.archlinux.org/task/72163
+git init -b master $TMPDIR
 cp $PKGBASE/trunk/* $TMPDIR
 
 pushd $TMPDIR
+git remote add origin "ssh://aur@aur.archlinux.org/$REPONAME.git"
 makepkg --printsrcinfo > .SRCINFO
 git add .SRCINFO
 git add *
 
 git commit -m 'import from community'
-git push
+git push origin master
 
 popd


### PR DESCRIPTION
When your default git branch is main `git clone`, clones an empty repo
from the AUR as main and as the AUR does not support main pushing fails.