### PR TITLE
checkservices: do not require running as root to parse cli options

### DIFF
--- a/admin/checkservices
+++ b/admin/checkservices
@@ -278,11 +278,11 @@ main() {
     # avoid to be sighup'ed by interactive shell
     trap '' SIGHUP
 
-    # from now, we need to be root
-    (( $UID != 0 )) && error 'You need to be root' && exit 1
-
     # parse command line options
     argparse "$@"
+
+    # from now, we need to be root
+    (( $UID != 0 )) && error 'You need to be root' && exit 1
 
     # call pacdiff to ensure config files are updated before restart
     if (( $PACDIFF )); then


### PR DESCRIPTION
This avoids silly errors like
```
$ checkservices -h
Error:: You need to be root
```