### PR TITLE
checkservices: honor -R flag

### DIFF
--- a/admin/checkservices
+++ b/admin/checkservices
@@ -297,10 +297,14 @@ main() {
     local -a broken_services=($(get_broken_maps))
     echo "Found: ${#broken_services[@]}"
     if (( ${#broken_services[@]} )); then
-        display_restart "${broken_services[@]}"
-        if confirm 'Execute?'; then
-            arrow 'Restart broken services'
-            restart_services "${broken_services[@]}"
+        if (( RESTART )); then
+            display_restart "${broken_services[@]}"
+            if confirm 'Execute?'; then
+                arrow 'Restart broken services'
+                restart_services "${broken_services[@]}"
+            fi
+        else
+             display_restart "${broken_services[@]}" | sed "s/systemctl restart //g"
         fi
     fi
 
@@ -308,10 +312,14 @@ main() {
     local -a missing_services=($(get_missing_dbus))
     echo "Found: ${#missing_services[@]}"
     if (( ${#missing_services[@]} )); then
-        display_restart "${missing_services[@]}"
-        if confirm 'Execute?'; then
-            arrow 'Restart missing services'
-            restart_services "${missing_services[@]}"
+        if (( RESTART )); then
+            display_restart "${missing_services[@]}"
+            if confirm 'Execute?'; then
+                arrow 'Restart missing services'
+                restart_services "${missing_services[@]}"
+            fi
+        else
+            display_restart "${missing_services[@]}" | sed "s/systemctl restart //g"
         fi
     fi
 


### PR DESCRIPTION
Even though the -R flag were parsed it were not honored and there was no way to skip being asked for restart with the -R flag. Useful for putting checkservices in an alpm hook.