### PR TITLE
.github: update deprecated checkout action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: pacman -Syu --noconfirm make flake8 shellcheck
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run tests
         run: |
            make PREFIX=/usr DESTDIR="$(mktemp -d)" install


### PR DESCRIPTION
Fixed Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
