### PR TITLE
Fix typo in rebuild-todo's help message/example

### DIFF
--- a/package/rebuild-todo
+++ b/package/rebuild-todo
@@ -46,7 +46,7 @@ usage() {
 		    Rebuilds all packages from [extra] towards [extra-testing]
 		    $  ${PROGNAME} --extra --testing "https://archlinux.org/todo/some-todo-list/"
 
-		    Rebuilds all packages from [core] towards [extra-testing]
+		    Rebuilds all packages from [core] towards [core-staging]
 		    $  ${PROGNAME} --core --staging -m "binutils rebuild" "https://archlinux.org/todo/some-todo-list/"
 
 		    Rebuilds all packages from stdin (from [core]) towards [staging]


### PR DESCRIPTION
One of the example shown in the rebuild-todo's help message incorrectly mentions [extra-testing] as the repo target instead of [core-staging].