### PR TITLE
Add -o/--offload support to rebuild-todo

### DIFF
--- a/package/rebuild-todo
+++ b/package/rebuild-todo
@@ -25,6 +25,7 @@ usage() {
 		    -i, --ignore    Give one or more pkgbases to ignore
 		    -f, --filter    Filter for one or more maintainers (orphan for orphan packages)
 		    -e, --edit      Edit PKGBUILD before building. Default when todo type is "Task"
+		    -o, --offload   Use offloaded builds
 		    -h, --help      Show this help text
 		    --dry-run       Show the offload-build and commitpkg being ran
 		    --no-build      Don't build PKGBUILD
@@ -42,6 +43,9 @@ usage() {
 		Examples:
 		    Rebuilds all packages in [extra] towards [extra] ignoring "archlinux-contrib"
 		    $  ${PROGNAME} -i "archlinux-contrib" "https://archlinux.org/todo/some-todo-list/"
+
+		    Rebuilds all packages in [extra] towards [extra] using offloaded builds
+		    $  ${PROGNAME} -o "https://archlinux.org/todo/some-todo-list/"
 
 		    Rebuilds all packages from [extra] towards [extra-testing]
 		    $  ${PROGNAME} --extra --testing "https://archlinux.org/todo/some-todo-list/"
@@ -64,6 +68,7 @@ EDIT_PKGBUILD=0
 CONTINUE=0
 SKIP_BROKEN=0
 URL=""
+OFFLOAD=""
 REPO=""
 message=""
 filter=("extra")
@@ -100,6 +105,9 @@ while ((${#})); do
         ;;
         -e|--edit)
             EDIT_PKGBUILD=1
+        ;;
+        -o|--offload)
+            OFFLOAD="$key"
         ;;
         -d|--dry-run)
             DRY=1
@@ -195,7 +203,7 @@ if ((DRY)); then
     echo "Would rebuild the following packages:"
     printf '    %s\n' "${packages[@]}"
     echo "With:"
-    echo "    pkgctl build --rebuild $REPO"
+    echo "    pkgctl build --rebuild $REPO $OFFLOAD"
     echo "    pkgctl release --db-update $REPO -m \"$message\""
     exit 0
 fi
@@ -225,7 +233,7 @@ for pkg in "${packages[@]}"; do
         if ! ((NO_BUILD)); then
             SKIP_BUILD=0
             while true; do
-                if pkgctl build --rebuild $REPO; then
+                if pkgctl build --rebuild $REPO $OFFLOAD; then
                     rebuilt_packages+=("$pkg")
                     break
                 else


### PR DESCRIPTION
Use the -o/--offload flag to use offloaded builds in rebuild-todo (via pkgctl build -o/--offload)