### PR TITLE
Add a configurable "ignored service" list to checkservices

### DIFF
--- a/admin/checkservices
+++ b/admin/checkservices
@@ -55,6 +55,9 @@ SERIALIZE=0         # run in parallel
 STATUS=1            # display status after systemctl
 USER_SLICE=0        # act on users services
 
+# ignored service list
+IGNORED_SERVICES=("getty@tty.*.service" "systemd-logind.service" "dbus-broker.service")
+
 # print $* as an arrow line
 arrow() {
     printf "${C_BOLD}${C_BLUE}:: ${C_WHITE}%s${C_RESET}\n" "$*"
@@ -102,7 +105,7 @@ confirm() {
 
 # get running systemd services
 get_services() {
-    systemctl --no-legend --full --type service --state running | tr -d '●' | awk '{print $1}'
+    systemctl --no-legend --full --type service --state running | tr -d '●' | awk '{print $1}' | grep -v $(printf -- '-e %s ' "${IGNORED_SERVICES[@]}")
 }
 
 # get systemd services with updated mapped files
@@ -249,6 +252,7 @@ usage() {
     echo "  -s/-S: display (or not) status of restarted service (default: $STATUS)" >&2
     echo "  -u/-U: act (or not) on services in users slice (default: $USER_SLICE)" >&2
     echo "  -z/-Z: serialize (or not) action (default: $SERIALIZE)" >&2
+    echo "  -i 'service_name'.service: ignore a specific service (can be used multiple times)" >&2
     exit 2
 }
 
@@ -256,7 +260,7 @@ usage() {
 # set options as global vars
 argparse() {
     local opt
-    while getopts 'AahFfLlPpRrSsUuZz' opt; do
+    while getopts 'AahFfLlPpRrSsUuZzi:' opt; do
         case $opt in
             A) AUTOCONFIRM=0;;      a) AUTOCONFIRM=1;;
             F) FAILED=0;;           f) FAILED=1;;
@@ -266,6 +270,12 @@ argparse() {
             S) STATUS=0;;           s) STATUS=1;;
             U) USER_SLICE=0;;       u) USER_SLICE=1;;
             Z) SERIALIZE=0;;        z) SERIALIZE=1;;
+	    i) if [[ "$OPTARG" == *.service ]]; then
+                    IGNORED_SERVICES+=("$OPTARG")
+	       else
+		    usage
+               fi
+               ;;
             *) usage;;
         esac
     done


### PR DESCRIPTION
This commit aims to introduce an ignored service list that contains services that are known to cause parsing errors and/or issues when being restarted. Elements can be added to the list with the `-i "service_name".service` option (e.g. `checkservices -i sddm.service -i NetworkManager.service`)

Show usage and exit if the `-i` argument does not finish with `.service` (to ensure a precise parsing and avoid unexpected filtering)

Fixes https://github.com/archlinux/contrib/issues/44