### PR TITLE
Update checkservices help message to be less confusing

### DIFF
--- a/admin/checkservices
+++ b/admin/checkservices
@@ -253,17 +253,18 @@ reload_systemd() {
 usage() {
     echo "usage ${0##*/} [options]"
     echo "description: check for updated files in a service"
+    echo "For toggle options: lowercase enables (1), uppercase disables (0)"
     echo 'options:'
     echo '  -h: this help' >&2
-    echo "  -a/-A: auto confirmation (or not) (default: $AUTOCONFIRM)" >&2
-    echo "  -l/-L: call (or not) systemd daemon-(reload|reexec) (default: $RELOAD)" >&2
-    echo "  -f/-F: display (or not) failed services before quit (default: $FAILED)" >&2
-    echo "  -p/-P: call (or not) pacdiff before act (default: $PACDIFF)" >&2
-    echo "  -r/-R: restart (or not) services with updated files (default: $RESTART)" >&2
-    echo "  -s/-S: display (or not) status of restarted service (default: $STATUS)" >&2
-    echo "  -u/-U: act (or not) on services in users slice (default: $USER_SLICE)" >&2
-    echo "  -m/-M: act (or not) on services in machine slice (default: $MACHINE_SLICE)" >&2
-    echo "  -z/-Z: serialize (or not) action (default: $SERIALIZE)" >&2
+    echo "  -a/-A: auto confirmation (default: -A / $AUTOCONFIRM)" >&2
+    echo "  -l/-L: call systemd daemon-(reload|reexec) (default: -l / $RELOAD)" >&2
+    echo "  -f/-F: display failed services before quit (default: -f / $FAILED)" >&2
+    echo "  -p/-P: call pacdiff before act (default: -p / $PACDIFF)" >&2
+    echo "  -r/-R: restart services with updated files (default: -r / $RESTART)" >&2
+    echo "  -s/-S: display status of restarted service (default: -s / $STATUS)" >&2
+    echo "  -u/-U: act on services in users slice (default: -U / $USER_SLICE)" >&2
+    echo "  -m/-M: act on services in machine slice (default: -M / $MACHINE_SLICE)" >&2
+    echo "  -z/-Z: serialize action (default: -Z / $SERIALIZE)" >&2
     echo "  -i 'service_name'.service: ignore a specific service (can be used multiple times)" >&2
     exit 2
 }


### PR DESCRIPTION
Before:

```
usage checkservices [options]
description: check for updated files in a service
options:
  -h: this help
  -a/-A: auto confirmation (or not) (default: 0)
  -l/-L: call (or not) systemd daemon-(reload|reexec) (default: 1)
  -f/-F: display (or not) failed services before quit (default: 1)
  -p/-P: call (or not) pacdiff before act (default: 1)
  -r/-R: restart (or not) services with updated files (default: 1)
  -s/-S: display (or not) status of restarted service (default: 1)
  -u/-U: act (or not) on services in users slice (default: 0)
  -m/-M: act (or not) on services in machine slice (default: 0)
  -z/-Z: serialize (or not) action (default: 0)
  -i 'service_name'.service: ignore a specific service (can be used multiple times)
  ```
  
  After:
  
  ```
  usage checkservices [options]
description: check for updated files in a service
For toggle options: lowercase enables (1), uppercase disables (0)
options:
  -h: this help
  -a/-A: auto confirmation (default: -A / 0)
  -l/-L: call systemd daemon-(reload|reexec) (default: -l / 1)
  -f/-F: display failed services before quit (default: -f / 1)
  -p/-P: call pacdiff before act (default: -p / 1)
  -r/-R: restart services with updated files (default: -r / 1)
  -s/-S: display status of restarted service (default: -s / 1)
  -u/-U: act on services in users slice (default: -U / 0)
  -m/-M: act on services in machine slice (default: -M / 0)
  -z/-Z: serialize action (default: -Z / 0)
  -i 'service_name'.service: ignore a specific service (can be used multiple times)
  ```
  
 Addresses part of https://github.com/archlinux/contrib/issues/92