### PR TITLE
chore: Add gitignore for the releases directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+releases/


### PR DESCRIPTION
It is automatically created by the Makefile and should not be added to git.