### PR TITLE
Update the release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 PREFIX = /usr/local
 SHAREDIR = $(PREFIX)/share/archlinux
 BINDIR = $(PREFIX)/bin
-REPO = contrib
-TAG = $(shell git describe --abbrev=0 --tags)
 
 BASH_SCRIPTS = \
 	admin/checkservices \
@@ -37,17 +35,12 @@ uninstall:
 	done;
 	rmdir $(DESTDIR)$(BINDIR)
 
-.PHONY: tag
-tag:
-	git describe --exact-match >/dev/null 2>&1 || git tag -s $(shell date +%Y%m%d)
-	git push --tags
-
 .PHONY: release
 release:
-	mkdir -p releases
-	git archive --prefix=${REPO}-${TAG}/ -o releases/${REPO}-${TAG}.tar.gz ${TAG};
-	gpg --detach-sign -o releases/${REPO}-${TAG}.tar.gz.sig releases/${REPO}-${TAG}.tar.gz
-	hub release create -m "Release: ${TAG}" -a releases/${REPO}-${TAG}.tar.gz.sig -a releases/${REPO}-${TAG}.tar.gz ${TAG}
+	git describe --exact-match >/dev/null 2>&1 && { echo "Last commit is already tagged" >&2; exit 1; }
+	git tag -s $(shell date +%Y%m%d)
+	git push --tags
+	gh release create --generate-notes $(shell date +%Y%m%d)
 
 check: check-bash check-python
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,14 @@ years so they can be curated, cleaned up and maybe become part of the `devtools`
 package.
 
 ### Contribution guidelines
+
 - Some documentation is needed. This can be comments in the top of the file or
   a traditional help command.
 
 - One ACK for each Pull-Request is needed
 
 - Please add [SPDX license header](https://spdx.org/ids-how)
+
+### Release process
+
+Run `make release` to push a signed git tag and create a release with default changelog (requires `gh`).


### PR DESCRIPTION
- Drop the custom made tarball: We now rely on [signed git tags](https://gitlab.archlinux.org/archlinux/packaging/packages/archlinux-contrib/-/commit/50905be547cd72eb1bcd1efab5b988e00781b883) for the package, which is more straightforward and transparent. IMO there's no need to keep creating this extra tarball.

- Move the whole release process into a single `release` target

- Switch to `gh`: `hub` throws an error (not sure if it's broken or expects something missing)

- Document the release process in the README