### PR TITLE
rebuild-todo: Drop irrelevant "pkg has already been rebuilt" check

### DIFF
--- a/package/rebuild-todo
+++ b/package/rebuild-todo
@@ -240,40 +240,37 @@ fi
 for pkg in "${packages[@]}"; do
     pushd "$pkg" &>/dev/null
 
-    # This should help us figure out if the package is already built
-    readarray -t pkgs < <(makepkg --packagelist)
-    if [[ -f ${pkgs[0]} ]]; then
-        echo "${pkg[0]} has already been rebuilt!"
-    else
-        if ((EDIT_PKGBUILD)); then
-            "$EDITOR" PKGBUILD
-        fi
-        if ! ((NO_BUILD)); then
-            SKIP_BUILD=0
-            while true; do
-                if pkgctl build --rebuild $REPO $OFFLOAD $NOCHECK; then
-                    rebuilt_packages+=("$pkg")
-                    break
-                else
-                    skipped_packages+=("$pkg")
-                fi
-                if ((SKIP_BROKEN)); then
-                    SKIP_BUILD=1
-                    break
-                fi
-                echo "We failed to build! You are in a subshell to fix the build. Exit the shell to build again."
-                $SHELL || true
-                read -p "Skip build? [N/y] " -n 1 -r
-                if [[ $REPLY =~ ^[Yy]$ ]]; then
-                    SKIP_BUILD=1
-                    break
-                fi
-            done
-            if ((SKIP_BUILD)); then
-                popd &>/dev/null
-                continue
+    if ((EDIT_PKGBUILD)); then
+        "$EDITOR" PKGBUILD
+    fi
+
+    if ! ((NO_BUILD)); then
+        SKIP_BUILD=0
+        while true; do
+            if pkgctl build --rebuild $REPO $OFFLOAD $NOCHECK; then
+                rebuilt_packages+=("$pkg")
+                break
+            else
+                skipped_packages+=("$pkg")
             fi
+            if ((SKIP_BROKEN)); then
+                SKIP_BUILD=1
+                break
+            fi
+            echo "We failed to build! You are in a subshell to fix the build. Exit the shell to build again."
+            $SHELL || true
+            read -p "Skip build? [N/y] " -n 1 -r
+            if [[ $REPLY =~ ^[Yy]$ ]]; then
+                SKIP_BUILD=1
+                break
+            fi
+        done
+
+        if ((SKIP_BUILD)); then
+            popd &>/dev/null
+            continue
         fi
+
         if ! ((NO_PUBLISH)); then
             if pkgctl release --db-update $REPO -m "$message"; then
                 remove_from_rebuilt_packages_list "$pkg"


### PR DESCRIPTION
This check is currently irrelevant and incorrect as it checks for the presence of a built package **before** the pkgrel is being bumped, therefore checking for a different package release than the one we will actually build right after.

This results in eventual false positives if you run `rebuild-todo` in your main packaging tree or with a global `$PKGDEST` set.

To be more relevant, this check should happen between the `pkgrel` bump and the build. But `pkgctl` does both in a single call, so that would imply some re-writing.
Regardless, the only thing this check might preserve people from is a bit of compute time by *eventually* avoiding to rebuild a package that was already built. This arguably isn't worth the eventual false positives. `pkgctl` won't let you push a package release that already exists in the repository anyway.

Basically, this check currently does more harm than good for little (eventual) benefit. Let's drop it.

Fixes https://github.com/archlinux/contrib/issues/103